### PR TITLE
Update README.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ var fs = require('fs');
 // returns the path to the word list which is separated by `\n`
 var wordListPath = require('word-list-fa');
 
-var wordArray = fs.readFileSync(wordListPath, 'utf8').split('\n');
+var wordArray = fs.readFileSync(wordListPath.path, 'utf8').split('\n');
 //=> [..., 'آبان', 'رفیق', ...]
 ```
 


### PR DESCRIPTION
On line 27, I changed the first argument from 'wordListPath' to 'wordListPath.path'. wordListPath by itself is an object and this line of code will give you an error because readFileSync wants a string as an argument (see node.js documentation).